### PR TITLE
Include media css files in setup.py package data

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -42,7 +42,10 @@ setup(
         "*.tests", "*.tests.*", "tests.*", "tests", "*.test*",
     ]),
     package_data={
-        "": ["media/*.png", "media/*.ico", "media/*.icns", "media/*.txt",],
+        "": [
+            "media/*.png", "media/*.ico", "media/*.icns", "media/*.txt",
+            "media/*.css",
+        ],
     },
     zip_safe=False,
     setup_requires=[


### PR DESCRIPTION
When using pip to install the hyo2.abc package the css file required by [`app_style.py`](https://github.com/hydroffice/hyo2_abc/blob/master/hyo2/abc/app/app_style.py#L22) is not installed into site-packages.

The following error occurs when other applications (QAX in this case) attempt to use the AppStyle class.
```
Traceback (most recent call last):
  File "/home/parallels/anaconda3/envs/qax-env/bin/qax", line 11, in <module>
    load_entry_point('hyo2.qax', 'gui_scripts', 'qax')()
  File "/home/parallels/work/project/qa4mbes/repo/hyo2_qax/hyo2/qax/app/gui.py", line 37, in gui
    app.setStyleSheet(AppStyle.load_stylesheet())
  File "/home/parallels/anaconda3/envs/qax-env/lib/python3.6/site-packages/hyo2/abc/app/app_style.py", line 24, in load_stylesheet
    with open(style_path) as fid:
FileNotFoundError: [Errno 2] No such file or directory: '/home/parallels/anaconda3/envs/qax-env/lib/python3.6/site-packages/hyo2/abc/app/media/app.css'

```

This PR includes css files in the setup.py package_data dictionary so they are installed into site-packages along with the rest of the library.