### PR TITLE
Use glob to recursively include all png files in media

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,8 @@ setup(
     ]),
     package_data={
         "": [
-            "media/*.png", "media/*.ico", "media/*.icns", "media/*.txt",
-            "media/*.css",
+            "media/*.png", "media/**/*.png", "media/*.ico", "media/*.icns",
+            "media/*.txt", "media/*.css"
         ],
     },
     zip_safe=False,


### PR DESCRIPTION
When using pip to install the hyo2.abc package some of the png files referenced within the `app.css` are not installed into site-packages. These png images are used for various Qt widgets (eg; checkboxes, combo boxes) and when missing cause the widgets to render incorrectly.

png files directly within the `media/` folder were included, however png files within the `media/rc/` folder were *not* included. This change will include png files from any subfolder under `media/`.

