### PR TITLE
Modified setup.py to support extras_require

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,16 +55,16 @@ setup(
     ],
     install_requires=[
         "appdirs",
-        "bidict",
-        "cartopy[plotting]",
         "gdal",
-        "matplotlib",
-        "numpy",
-        "psutil",
         "pyproj",
-        "PySide2",
-        "pywin32 ; platform_system=='Windows'"
+        "numpy",
     ],
+    extras_require={
+        "extended": [
+            "psutil",
+            "PySide2",
+            "pywin32 ; ""platform_system=='Windows'"],
+    },
     python_requires='>=3.5',
     entry_points={
         "gui_scripts": [


### PR DESCRIPTION
the 'extended' extra_requirements package list was added to setup.py to support a light weight default hyo2_abc

 'extended' extra_requirements added to provide support for gui applications. 

Some unused packages were removed

File inspection table:

Package | Modules
-- | --
appdirs | lib/helper
bidict |  
cartopy[plotting] |  
gdal | lib/gdal_aux; app/app_info; app/dialog/about/tabs/gdal_info
matplotlib | Dependency of cartopy
numpy | Dependency of  gdal, pyside2, cartopy
psutil | app/dialogs/about/tabs
pyproj | lib/gdal_aux
pyside2 | app/*
pywin32 | Maybe a dep for pyside2? Can’t tell

Testing:
Short hand list of tests conducted.

- Package manager (conda), conda create  -n hyo2_abc, conda install [install_requires], pip install -e . => 
Pip did not install any extra dependencies.
- Package manager (conda), conda create -n hyo2_abc, conda install [install_requires], pip install -e .[extended] =>
 Pip installed extra dependencies: shiboken2, pywin32, pyside2, psutil

Further testing needed?

